### PR TITLE
Call super.layoutSubviews() after changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,11 +445,15 @@ class TextView: UIView {
     private let textLabel = UILabel()
 
     override func layoutSubviews() {
-        super.layoutSubviews()
-
+        // Changing the labels changes their intrinsic size, do so before you call super's layoutSubviews()
+        
         titleLabel.text = state.title
         textLabel.text = state.text
 
+        // Perform default layout
+        super.layoutSubviews()
+
+        // Do your custom layout steps (if any)
         ...
     }
 }


### PR DESCRIPTION
Changing the text of UILabels most likely will change their intrinsic size.
Calling super.layoutSubviews() before doing so will miss this change and require another layout cycle.
Thus I suggest to move the call past the text change.